### PR TITLE
WPOS: Pass $taxonomy to term_item_url filter

### DIFF
--- a/walkers/SubmenuWalker.php
+++ b/walkers/SubmenuWalker.php
@@ -839,7 +839,7 @@ class JC_Submenu_Nav_Walker extends Walker_Nav_Menu {
 			$t->title = apply_filters( 'jcs/term_item_title', $t->title, $t->ID );
 
 			$t->url = apply_filters( 'jcs/item_url', get_term_link( $t, $taxonomy ), $t->ID , 'term');
-			$t->url = apply_filters( 'jcs/term_item_url', $t->url, $t->ID );
+			$t->url = apply_filters( 'jcs/term_item_url', $t->url, $t->ID, $taxonomy );
 
 			$t->classes = array();
 			


### PR DESCRIPTION
Hi @jcollings. I really love this plugin so I made a modification for it to be more customisable.

I find it's necessary to pass the $taxonomy to the filter `jcs/term_item_url` so that I could process the term url  based on it's taxonomy.

**The main reason** I had to do this: 

I could not process anything based on the **term id** alone, as the function get_term require $taxonomy input. So, I think we'd rather pass the $taxonomy along instead of trying to get a DB query to find out this value for each and every URL parse. In my case, it will be hundreds in the loop.

I believe it should be of use to the public, so I decided to make a pull request to your repo.

This is small contribution and I hope you are going to accept it as a token of our co-operation, as I will soon add more feature to this plugin as I am actively using it.

Sincerly,
Binh WPOS
